### PR TITLE
Fix loop condition in nametest

### DIFF
--- a/sys/src/cmd/9nfs/nametest.c
+++ b/sys/src/cmd/9nfs/nametest.c
@@ -34,7 +34,7 @@ main(int argc, char **argv)
 	}
 	mapinit(argv[0], 0);
 	in = Bopen("/fd/0", OREAD);
-	while(l = Brdline(in, '\n')){	/* assign = */
+	while((l = Brdline(in, '\n')) != nil){	/* assign = */
 		l[Blinelen(in)-1] = 0;
 		arc = strparse(l, nelem(arv), arv);
 		if(arc <= 0)


### PR DESCRIPTION
## Summary
- Prevent accidental loop continuation by explicitly checking for a `nil` return from `Brdline`

## Testing
- `gcc -Wall -Werror sys/src/cmd/9nfs/nametest.c -c` *(fails: fatal error: u.h: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_6893545fc558832c9589c65dd629f600